### PR TITLE
Bug Fix: set the Busy flag earlier

### DIFF
--- a/ContactsApp.Controls/EditContactControl.razor
+++ b/ContactsApp.Controls/EditContactControl.razor
@@ -88,11 +88,17 @@ else
     /// <returns>A <see cref="Task"/>.</returns>
     protected override async Task OnParametersSetAsync()
     {
-        Service.SetUser(User);
-        Busy = true; // start async
+        //Busy = true; // start async
         Contact = await Service.Repo.LoadAsync(ContactId, null, true);
         Busy = false; // end async
+
         await base.OnInitializedAsync();
+    }
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        Busy = true;
+        await base.SetParametersAsync(parameters);
     }
 
     /// <summary>


### PR DESCRIPTION
The Blazor Lifecycle means we should set the flag a little earlier to avoid an showing the "id not found" msg _before_ we've had a chance to try and find it.